### PR TITLE
Use translated title as anchors

### DIFF
--- a/lib/unique_head.rb
+++ b/lib/unique_head.rb
@@ -7,10 +7,10 @@ class UniqueHeadCounter < Middleman::Renderers::MiddlemanRedcarpetHTML
     @head_count = {}
   end
   def header(text, header_level)
-    friendly_text = text.gsub(/<[^>]*>/,"").parameterize
+    # use translated titles as anchors
+    friendly_text = eval('I18n.' + text.gsub('&#39;', '\'')).downcase.split.join('_')
 
-    # remove translation tags from anchors
-    friendly_text = friendly_text.gsub(/t-39-(.*)-39/,'\1')
+    friendly_text = friendly_text.gsub(/<[^>]*>/,"").parameterize
 
     if friendly_text.strip.length == 0
       # Looks like parameterize removed the whole thing! It removes many unicode


### PR DESCRIPTION
On obtient des ancres telles que cela (sur /fr):
"introduction"
"authentification"
"trouver_ses_cles_api"
"niveaux_d-acces_des_cles_d-identification"
"pagination"
"parametre"
"ping"
"tester_le_fonctionnement_de_l-api"
"cve_announcements"
"recuperation_de_toutes_les_cve"
"recuperer_une_cve_specifique"
"groupes"
"recuperation_de_tous_les_groupes"
"recuperation_d-un_groupe"
"creation_d-un_nouveau_groupe"
"modification_d-un_groupe_existant"
"suppression_d-un_groupe"
"hotes"
"recuperation_de_tous_les_hotes"
"recuperation_d-un_hote"
"creation_d-un_nouvel_hote"
"modification_d-un_hote_existant"
"supprimer_un_hote"
"connexions_sans-agent"
"recuperation_de_toutes_les_connexions_sans-agent"
"recuperation_d-une_connexion_sans-agent"
"creation_d-une_connexion_sans-agent"
"modification_d-une_connexion_sans-agent"
"verification_du_deploiement_d-une_connexion_sans-agent"
"suppression_d-une_connexion_sans_agent"
"serveurs"
"recuperation_de_tous_les_serveurs"
